### PR TITLE
Fix minor typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ This extension allows you to use a Rest API with Refinery CMS 3.0 and later.
 Simply put this in the Gemfile of your Refinery application:
 
 ```ruby
-gem 'refinerycms-api', github: 'refinerycms-contrib/refinerycms-api', master: 'branch'
+gem 'refinerycms-api', github: 'refinerycms-contrib/refinerycms-api', branch: 'master'
 ```
 
 Then run `bundle install` to install it.


### PR DESCRIPTION
As it was written, generates the following error on `bundle install`:

``````
[!] There was an error parsing `Gemfile`: You passed :master as an option for gem 'refinerycms-api', but it is invalid. Valid options are: group, groups, git, path, glob, name, branch, ref, tag, require, submodules, platform, platforms, type, source, install_if, github, gist, bitbucket. Bundler cannot continue.```
``````
