### PR TITLE
Fix Internal Server Error when uploading invalid image via API

### DIFF
--- a/app/views/refinery/api/errors/invalid_resource.v1.rabl
+++ b/app/views/refinery/api/errors/invalid_resource.v1.rabl
@@ -1,3 +1,3 @@
 object false
 node(:error) { I18n.t(:invalid_resource, :scope => "refinery.api") }
-node(:errors) { @Array(@resource).map{|r| r.errors.to_hash } }
+node(:errors) { Array(@resource).map{|r| r.errors.to_hash } }

--- a/app/views/refinery/api/errors/invalid_resource.v1.rabl
+++ b/app/views/refinery/api/errors/invalid_resource.v1.rabl
@@ -1,3 +1,3 @@
 object false
 node(:error) { I18n.t(:invalid_resource, :scope => "refinery.api") }
-node(:errors) { @resource.errors.to_hash }
+node(:errors) { @Array(@resource).map{|r| r.errors.to_hash } }


### PR DESCRIPTION
@resouce contains an Array of Images in case an uploaded Image is invalid. This resulted in a 500 error ("undefined method `errors' for #<Array:....") instead of a 422 with appropriate error messages. This change simply displays all errors from all images.